### PR TITLE
Fix build for 5.10 and rearrange headers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,6 +65,9 @@ set(generated_cpp_suffix "_${QT_VERSION_MAJOR}${QT_VERSION_MINOR}")
 if("${generated_cpp_suffix}" STREQUAL "_510")
 	set(generated_cpp_suffix "_56") # Also use 5.6 wrappers for 5.10
 endif()
+if("${generated_cpp_suffix}" STREQUAL "_59")
+	set(generated_cpp_suffix "_56") # Also use 5.6 wrappers for 5.10
+endif()
 if("${generated_cpp_suffix}" STREQUAL "_58")
 	set(generated_cpp_suffix "_56") # Also use 5.6 wrappers for 5.8
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,6 +62,9 @@ endif(PythonQt_Qt5)
 # associated with the Qt version being used.
 
 set(generated_cpp_suffix "_${QT_VERSION_MAJOR}${QT_VERSION_MINOR}")
+if("${generated_cpp_suffix}" STREQUAL "_510")
+	set(generated_cpp_suffix "_56") # Also use 5.6 wrappers for 5.10
+endif()
 if("${generated_cpp_suffix}" STREQUAL "_58")
 	set(generated_cpp_suffix "_56") # Also use 5.6 wrappers for 5.8
 endif()

--- a/build/python.prf
+++ b/build/python.prf
@@ -1,14 +1,15 @@
 # profile to include and link Python
 
 # Change this variable to your python version (2.6, 2.7, 3.3, ...)
-win32:PYTHON_VERSION=27
+msvc:PYTHON_VERSION=27
 unix:PYTHON_VERSION=2.7
+mingw:PYTHON_VERSION=2.7
 
 macx {
   # for macx you need to have the Python development kit installed as framework
   INCLUDEPATH += /System/Library/Frameworks/Python.framework/Headers
   LIBS += -F/System/Library/Frameworks -framework Python
-} else:win32 {
+} else:msvc {
   # for windows install a Python development kit or build Python yourself from the sources
   # Make sure that you set the environment variable PYTHON_PATH to point to your
   # python installation (or the python sources/header files when building from source).
@@ -30,12 +31,15 @@ macx {
     DEBUG_EXT = 
   }
 
-  win32:INCLUDEPATH += $$(PYTHON_PATH)/PC $$(PYTHON_PATH)/include
-  win32:LIBS += $$(PYTHON_LIB)/python$${PYTHON_VERSION}$${DEBUG_EXT}.lib
+  INCLUDEPATH += $$(PYTHON_PATH)/PC $$(PYTHON_PATH)/include
+  LIBS += $$(PYTHON_LIB)/python$${PYTHON_VERSION}$${DEBUG_EXT}.lib
+} else:mingw {
+  LIBS += $$system(mingw32-pkg-config --libs python)
+  QMAKE_CXXFLAGS += $$system(mingw32-pkg-config --cflags python)
 } else:unix {
   # on linux, python-config is used to autodetect Python.
   # make sure that you have installed a matching python-dev package.
   
-  unix:LIBS += $$system(python$${PYTHON_VERSION}-config --libs)
-  unix:QMAKE_CXXFLAGS += $$system(python$${PYTHON_VERSION}-config --includes)
+  LIBS += $$system(python$${PYTHON_VERSION}-config --libs)
+  QMAKE_CXXFLAGS += $$system(python$${PYTHON_VERSION}-config --includes)
 }

--- a/examples/NicePyConsole/PygmentsHighlighter.cpp
+++ b/examples/NicePyConsole/PygmentsHighlighter.cpp
@@ -5,9 +5,6 @@
 */
 #include "PygmentsHighlighter.h"
 
-#include <PythonQt.h>
-
-
 PygmentsHighlighter::PygmentsHighlighter(QTextDocument *parentDoc) :
     QSyntaxHighlighter(parentDoc)
 {

--- a/examples/NicePyConsole/PygmentsHighlighter.h
+++ b/examples/NicePyConsole/PygmentsHighlighter.h
@@ -9,11 +9,11 @@
 #define PYGMENTSHIGHLIGHTER_H
 
 
-// Qt-includes
-#include <QSyntaxHighlighter>
-
 // PythonQt-includes
 #include <PythonQt.h>
+
+// Qt-includes
+#include <QSyntaxHighlighter>
 
 // local includes
 #include "SimpleConsole.h"

--- a/examples/NicePyConsole/PythonCompleter.h
+++ b/examples/NicePyConsole/PythonCompleter.h
@@ -8,11 +8,11 @@
 #ifndef PYTHONCOMPLETER_H
 #define PYTHONCOMPLETER_H
 
-// Qt-includes
-#include <QCompleter>
-
 // PythonQt-includes
 #include <PythonQt.h>
+
+// Qt-includes
+#include <QCompleter>
 
 // forward declarations
 class SimpleConsole;

--- a/examples/NicePyConsole/main.cpp
+++ b/examples/NicePyConsole/main.cpp
@@ -5,12 +5,12 @@
 */
 
 
-// Qt-includes
-#include <QApplication>
-
 // PythonQt-includes
 #include <PythonQt.h>
 #include <PythonQt_QtAll.h>
+
+// Qt-includes
+#include <QApplication>
 
 // includes
 #include "NicePyConsole.h"

--- a/extensions/PythonQt_QtAll/CMakeLists.txt
+++ b/extensions/PythonQt_QtAll/CMakeLists.txt
@@ -39,7 +39,7 @@ endif()
 
 qt_wrap_cpp(GEN_MOC ${GEN_HEADERS})
 
-add_library(${PythonQt_QtAll} ${SOURCES} ${HEADERS} ${GEN_SOURCES} ${GEN_MOC})
+add_library(${PythonQt_QtAll} ${SOURCES} ${HEADERS} ${GEN_SOURCES})
 target_link_libraries(${PythonQt_QtAll} ${PythonQt} ${PYTHON_LIBRARIES})
 target_include_directories(${PythonQt_QtAll} PUBLIC
 	$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -24,8 +24,7 @@ include_directories(${CMAKE_CURRENT_SOURCE_DIR})
 
 qt_wrap_cpp(GEN_MOC ${SOURCES_MOC})
 qt_add_resources(GEN_QRC ${SOURCES_QRC})
-
-add_library(${PythonQt} ${SOURCES} ${GEN_MOC} ${GEN_QRC} ${HEADERS})
+add_library(${PythonQt} ${SOURCES} ${GEN_QRC} ${HEADERS})
 if(PythonQt_DynamicMetaObject)
 	target_compile_definitions(${PythonQt} PRIVATE DYNAMIC_META_OBJECT_IMPLEMENTATION)
 endif()

--- a/src/PythonQtClassInfo.h
+++ b/src/PythonQtClassInfo.h
@@ -33,12 +33,12 @@
  *
  */
 
+#include "PythonQt.h"
 #include <QMetaObject>
 #include <QMetaMethod>
 #include <QHash>
 #include <QByteArray>
 #include <QList>
-#include "PythonQt.h"
 
 class PythonQtSlotInfo;
 class PythonQtClassInfo;

--- a/src/PythonQtMethodInfo.cpp
+++ b/src/PythonQtMethodInfo.cpp
@@ -39,8 +39,8 @@
 */
 //----------------------------------------------------------------------------------
 
-#include "PythonQtMethodInfo.h"
 #include "PythonQtClassInfo.h"
+#include "PythonQtMethodInfo.h"
 #include <iostream>
 
 QHash<QByteArray, PythonQtMethodInfo*> PythonQtMethodInfo::_cachedSignatures;

--- a/src/src.pri
+++ b/src/src.pri
@@ -3,7 +3,7 @@ DEFINES +=  PYTHONQT_EXPORTS
 INCLUDEPATH += $$PWD
 
 # This was needed to work around "number of sections exceeded object file format limit" linker error
-win32:QMAKE_CXXFLAGS += /bigobj
+msvc:QMAKE_CXXFLAGS += /bigobj
 
 HEADERS +=                    \
   $$PWD/PythonQt.h                  \

--- a/src/src.pro
+++ b/src/src.pro
@@ -38,3 +38,9 @@ include ( src.pri )
 
 include($${PYTHONQT_GENERATED_PATH}/com_trolltech_qt_core_builtin/com_trolltech_qt_core_builtin.pri)
 include($${PYTHONQT_GENERATED_PATH}/com_trolltech_qt_gui_builtin/com_trolltech_qt_gui_builtin.pri)
+
+public_headers.path = ../include
+public_headers.files = $$HEADERS
+
+INSTALLS += public_headers
+


### PR DESCRIPTION
The headers are rearranged to have the Python.h header included stl or Qt 
(quoting from https://docs.python.org/2/c-api/intro.html) 

> Since Python may define some pre-processor definitions which affect the standard headers on some systems, you must include Python.h before any standard headers are included.